### PR TITLE
Feat: soft delete 기능 추가

### DIFF
--- a/backend/src/main/java/kr/co/programmers/collabond/shared/domain/CreatedEntity.java
+++ b/backend/src/main/java/kr/co/programmers/collabond/shared/domain/CreatedEntity.java
@@ -2,6 +2,7 @@ package kr.co.programmers.collabond.shared.domain;
 
 import jakarta.persistence.*;
 import kr.co.programmers.collabond.shared.util.DeletedAtConverter;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SoftDelete;
 import org.springframework.data.annotation.CreatedDate;
@@ -9,6 +10,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
+@Getter
 @MappedSuperclass
 @SoftDelete(columnName = "deleted_at", converter = DeletedAtConverter.class)
 @EntityListeners(AuditingEntityListener.class)

--- a/backend/src/main/java/kr/co/programmers/collabond/shared/domain/CreatedEntity.java
+++ b/backend/src/main/java/kr/co/programmers/collabond/shared/domain/CreatedEntity.java
@@ -1,13 +1,16 @@
 package kr.co.programmers.collabond.shared.domain;
 
 import jakarta.persistence.*;
+import kr.co.programmers.collabond.shared.util.DeletedAtConverter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SoftDelete;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
 @MappedSuperclass
+@SoftDelete(columnName = "deleted_at", converter = DeletedAtConverter.class)
 @EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 public abstract class CreatedEntity {
@@ -19,4 +22,7 @@ public abstract class CreatedEntity {
     @CreatedDate
     @Column(name = "created_at", updatable = false, nullable = false)
     private LocalDateTime createdAt;
+
+    @Column(name = "deleted_at", insertable = false, updatable = false)
+    private LocalDateTime deletedAt;
 }

--- a/backend/src/main/java/kr/co/programmers/collabond/shared/domain/UpdatedEntity.java
+++ b/backend/src/main/java/kr/co/programmers/collabond/shared/domain/UpdatedEntity.java
@@ -2,6 +2,7 @@ package kr.co.programmers.collabond.shared.domain;
 
 import jakarta.persistence.*;
 import kr.co.programmers.collabond.shared.util.DeletedAtConverter;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SoftDelete;
 import org.springframework.data.annotation.CreatedDate;
@@ -10,6 +11,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
+@Getter
 @MappedSuperclass
 @SoftDelete(columnName = "deleted_at", converter = DeletedAtConverter.class)
 @EntityListeners(AuditingEntityListener.class)

--- a/backend/src/main/java/kr/co/programmers/collabond/shared/domain/UpdatedEntity.java
+++ b/backend/src/main/java/kr/co/programmers/collabond/shared/domain/UpdatedEntity.java
@@ -1,7 +1,9 @@
 package kr.co.programmers.collabond.shared.domain;
 
 import jakarta.persistence.*;
+import kr.co.programmers.collabond.shared.util.DeletedAtConverter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SoftDelete;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -9,6 +11,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import java.time.LocalDateTime;
 
 @MappedSuperclass
+@SoftDelete(columnName = "deleted_at", converter = DeletedAtConverter.class)
 @EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 public abstract class UpdatedEntity {
@@ -24,4 +27,7 @@ public abstract class UpdatedEntity {
     @LastModifiedDate
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at", insertable = false, updatable = false)
+    private LocalDateTime deletedAt;
 }

--- a/backend/src/main/java/kr/co/programmers/collabond/shared/util/DeletedAtConverter.java
+++ b/backend/src/main/java/kr/co/programmers/collabond/shared/util/DeletedAtConverter.java
@@ -1,0 +1,20 @@
+package kr.co.programmers.collabond.shared.util;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.time.LocalDateTime;
+
+@Converter
+public class DeletedAtConverter implements AttributeConverter<Boolean, LocalDateTime> {
+
+    @Override
+    public LocalDateTime convertToDatabaseColumn(Boolean isDeleted) {
+        return isDeleted ? LocalDateTime.now() : null;
+    }
+
+    @Override
+    public Boolean convertToEntityAttribute(LocalDateTime deletedAt) {
+        return deletedAt != null;
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -20,7 +20,7 @@ spring:
 
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:3306/cafe
+    url: jdbc:mysql://localhost:3306/collabond
     username: ${MYSQL_ID}
     password: ${MYSQL_PW}
 

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -20,7 +20,7 @@ spring:
 
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:3306/cafe
+    url: jdbc:mysql://localhost:3306/collabond
     username: ${MYSQL_ID}
     password: ${MYSQL_PW}
 


### PR DESCRIPTION
## 📌 관련 이슈
- #10 

## 💡 구현 내용 요약
- base entity를 상속받은 entity에 한해서 soft delete를 적용시켰습니다.

## ✅ 작업 상세 내용
- [Feat: Custom Converter 클래스 구현](https://github.com/prgrms-be-devcourse/NBE5-7-2-Team10/commit/19d3a5efcb155667343f3f93263e7daa3e851406)
하이버네이트 6.4에서 도입된 Soft Delete는 기본적으로 레코드의 삭제 여부를 boolean 타입으로 표기합니다.
저희는 삭제 시점으로 관리하기 때문에, boolean 타입에서 LocalDateTime으로 바꿔줘야 합니다.
때문에, Custom Converter를 구현했습니다.

- [Feat: Base Entity에 Soft Delete 적용](https://github.com/prgrms-be-devcourse/NBE5-7-2-Team10/commit/fa4f342eab010993423af075b48e84dcae237bee)
Base Entity에 deletedAt 변수를 추가했고, 하이버네이트의 `@SoftDelete`와 Custom Converter를 통해 soft delete를 적용시켰습니다.

## 📎 기타 참고 사항
- 비교적 최근에 출시한 기능이고 사용해본적이 없어서 잘 작동할지 모르겠지만, 이후에 구현하면서 테스트 진행해보겠습니다.