### PR TITLE
Feat: 메일 발송 기능 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'

--- a/backend/src/main/java/kr/co/programmers/collabond/api/apply/application/ApplyPostService.java
+++ b/backend/src/main/java/kr/co/programmers/collabond/api/apply/application/ApplyPostService.java
@@ -10,6 +10,9 @@ import kr.co.programmers.collabond.api.apply.interfaces.ApplyPostMapper;
 import kr.co.programmers.collabond.api.attachment.domain.Attachment;
 import kr.co.programmers.collabond.api.file.application.FileService;
 import kr.co.programmers.collabond.api.file.domain.File;
+import kr.co.programmers.collabond.api.mail.dto.ReceivedApplyMailSendRequestDto;
+import kr.co.programmers.collabond.api.mail.interfaces.MailMapper;
+import kr.co.programmers.collabond.api.mail.service.MailService;
 import kr.co.programmers.collabond.api.profile.domain.Profile;
 import kr.co.programmers.collabond.api.profile.infrastructure.ProfileRepository;
 import kr.co.programmers.collabond.api.recruit.domain.RecruitPost;
@@ -38,6 +41,7 @@ public class ApplyPostService {
 
     private final ApplyPostRepository applyPostRepository;
     private final FileService fileService;
+    private final MailService mailService;
     private final RecruitPostRepository recruitPostRepository;
     private final ProfileRepository profileRepository;
     private final UserRepository userRepository;
@@ -73,6 +77,11 @@ public class ApplyPostService {
         applyPost.updateAttachment(attachments);
 
         ApplyPost save = applyPostRepository.save(applyPost);
+
+        ReceivedApplyMailSendRequestDto mailSendRequestDto =
+                MailMapper.toDto(recruitPost, profile, save.getCreatedAt());
+
+        mailService.sendReceivedApplyMail(mailSendRequestDto);
 
         return ApplyPostMapper.toDto(save);
     }

--- a/backend/src/main/java/kr/co/programmers/collabond/api/mail/dto/ReceivedApplyMailSendRequestDto.java
+++ b/backend/src/main/java/kr/co/programmers/collabond/api/mail/dto/ReceivedApplyMailSendRequestDto.java
@@ -1,0 +1,16 @@
+package kr.co.programmers.collabond.api.mail.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ReceivedApplyMailSendRequestDto {
+    private String recruitPostTitle; // 모집 글 제목
+    private String applicantName; // 지원자 이름
+    private String applicantProfileName; // 지원자 프로필 이름
+    private String receiverEmail; // 수신자(모집글 작성자) 이메일
+    private LocalDateTime appliedAt; // 지원 시간
+}

--- a/backend/src/main/java/kr/co/programmers/collabond/api/mail/interfaces/MailMapper.java
+++ b/backend/src/main/java/kr/co/programmers/collabond/api/mail/interfaces/MailMapper.java
@@ -1,0 +1,20 @@
+package kr.co.programmers.collabond.api.mail.interfaces;
+
+import kr.co.programmers.collabond.api.mail.dto.ReceivedApplyMailSendRequestDto;
+import kr.co.programmers.collabond.api.profile.domain.Profile;
+import kr.co.programmers.collabond.api.recruit.domain.RecruitPost;
+
+import java.time.LocalDateTime;
+
+public class MailMapper {
+    public static ReceivedApplyMailSendRequestDto toDto(
+            RecruitPost recruitPost, Profile applicantProfile, LocalDateTime appliedAt) {
+        return ReceivedApplyMailSendRequestDto.builder()
+                .recruitPostTitle(recruitPost.getTitle())
+                .applicantName(applicantProfile.getUser().getNickname())
+                .applicantProfileName(applicantProfile.getName())
+                .receiverEmail(recruitPost.getProfile().getUser().getEmail())
+                .appliedAt(appliedAt)
+                .build();
+    }
+}

--- a/backend/src/main/java/kr/co/programmers/collabond/api/mail/service/MailService.java
+++ b/backend/src/main/java/kr/co/programmers/collabond/api/mail/service/MailService.java
@@ -1,0 +1,65 @@
+package kr.co.programmers.collabond.api.mail.service;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import kr.co.programmers.collabond.api.mail.dto.ReceivedApplyMailSendRequestDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+
+import java.time.format.DateTimeFormatter;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class MailService {
+
+    @Value("${custom.mail.subject.apply-received}")
+    private String applyReceivedSubject;
+
+    private final JavaMailSender mailSender;
+    private final TemplateEngine templateEngine;
+
+    public void sendReceivedApplyMail(ReceivedApplyMailSendRequestDto request) {
+        Context context = new Context();
+        context.setVariable("recruitPostTitle", request.getRecruitPostTitle());
+        context.setVariable("applicantName", request.getApplicantName());
+        context.setVariable("applicantProfileName", request.getApplicantProfileName());
+        context.setVariable("appliedAt", request.getAppliedAt());
+
+        sendTemplateMail(
+                request.getReceiverEmail(),
+                applyReceivedSubject,
+                "mail/apply-notification.html",
+                context
+        );
+    }
+
+    @Async
+    protected void sendTemplateMail(String to, String subject, String templateName, Context context) {
+        try {
+            MimeMessage mimeMessage = mailSender.createMimeMessage();
+            MimeMessageHelper mimeMessageHelper =
+                    new MimeMessageHelper(mimeMessage, true, "UTF-8");
+
+            String body = templateEngine.process(templateName, context);
+
+            mimeMessageHelper.setTo(to);
+            mimeMessageHelper.setSubject(subject);
+            mimeMessageHelper.setText(body, true);
+
+            mailSender.send(mimeMessage);
+        } catch (MessagingException e) {
+            log.error("이메일 전송 오류 : " + e.getMessage());
+            throw new RuntimeException(e);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -75,7 +75,6 @@ logging:
   level:
     org.springframework.security: TRACE
 
-
 custom:
   file:
     path: ${user.home}/collabond/images/  # ?? ?? ??
@@ -89,4 +88,5 @@ custom:
     redirect-main: http://localhost:3000/oauth
     redirect-sign-up: http://localhost:3000/signup
   mail:
-    subject: ??
+    subject:
+      apply-received: [Collabond] 새로운 지원자가 있습니다!

--- a/backend/src/main/resources/templates/mail/apply-notification.html
+++ b/backend/src/main/resources/templates/mail/apply-notification.html
@@ -1,0 +1,149 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>지원 알림</title>
+    <style>
+        @font-face {
+            font-family: "GmarketSansMedium";
+            src: url("https://cdn.jsdelivr.net/gh/projectnoonnu/noonfonts_2001@1.1/GmarketSansMedium.woff") format("woff");
+            font-weight: normal;
+            font-style: normal;
+        }
+
+        * {
+            font-family: "GmarketSansMedium", 'Apple SD Gothic Neo', 'Malgun Gothic', sans-serif;
+        }
+
+        .container {
+            width: 100%;
+            max-width: 600px;
+            margin: 0 auto;
+            padding: 20px;
+            background-color: #ffffff;
+        }
+        .header {
+            text-align: center;
+            padding: 30px 20px;
+            background-color: #2EC4B6;
+            border-radius: 10px 10px 0 0;
+            margin-bottom: 0;
+        }
+        .header h1 {
+            color: #ffffff;
+            margin: 0;
+            font-size: 24px;
+            font-weight: 500;
+            letter-spacing: -0.5px;
+        }
+        .content {
+            padding: 30px;
+            background-color: #ffffff;
+            border: 1px solid #CBF3F0;
+            border-radius: 0 0 10px 10px;
+            box-shadow: 0 4px 6px rgba(0, 0, 0, 0.05);
+        }
+        .section {
+            margin-bottom: 25px;
+            padding: 15px;
+            border-radius: 8px;
+            background-color: #f8f9fa;
+        }
+        .section:hover {
+            background-color: #CBF3F0;
+            transition: background-color 0.3s ease;
+        }
+        .section-title {
+            font-weight: 500;
+            color: #2EC4B6;
+            margin-bottom: 12px;
+            font-size: 16px;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+            border-bottom: 2px solid #FF9F1C;
+            padding-bottom: 5px;
+            display: inline-block;
+        }
+        .info-item {
+            margin-bottom: 8px;
+            display: flex;
+            align-items: baseline;
+        }
+        .info-label {
+            color: #666;
+            min-width: 80px;
+            margin-right: 10px;
+            font-weight: 500;
+        }
+        .info-value {
+            color: #333;
+            font-weight: 500;
+            letter-spacing: -0.3px;
+        }
+        .highlight {
+            color: #FF9F1C;
+            font-weight: 500;
+        }
+        .footer {
+            text-align: center;
+            margin-top: 30px;
+            color: #666;
+            font-size: 0.9em;
+            padding: 20px;
+            background-color: #f8f9fa;
+            border-radius: 8px;
+        }
+        .brand-name {
+            color: #2EC4B6;
+            font-weight: 500;
+            font-size: 1.1em;
+            letter-spacing: -0.5px;
+        }
+        .copyright {
+            margin: 5px 0;
+            color: #999;
+            font-size: 0.9em;
+            letter-spacing: -0.3px;
+        }
+    </style>
+</head>
+<body style="background-color: #f5f5f5; margin: 0; padding: 40px 0;">
+<div class="container">
+    <div class="header">
+        <h1>✨ 새로운 지원자가 있습니다 ✨</h1>
+    </div>
+
+    <div class="content">
+        <div class="section">
+            <div class="section-title">모집 공고 정보</div>
+            <div class="info-item">
+                <span class="info-label">제목</span>
+                <span class="info-value highlight" th:text="${recruitPostTitle}"></span>
+            </div>
+        </div>
+
+        <div class="section">
+            <div class="section-title">지원 정보</div>
+            <div class="info-item">
+                <span class="info-label">이름</span>
+                <span class="info-value" th:text="${applicantName}"></span>
+            </div>
+            <div class="info-item">
+                <span class="info-label">프로필</span>
+                <span class="info-value" th:text="${applicantProfileName}"></span>
+            </div>
+            <div class="info-item">
+                <span class="info-label">지원 시간</span>
+                <span class="info-value" th:text="${#temporals.format(appliedAt, 'yyyy년 MM월 dd일 HH:mm')}"></span>
+            </div>
+        </div>
+    </div>
+
+    <div class="footer">
+        <div class="brand-name">COLLABOND</div>
+        <p style="margin: 5px 0;">본 메일은 자동으로 발송되었습니다.</p>
+        <p class="copyright">© 2024 Collabond. All rights reserved.</p>
+    </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## 📌 관련 이슈
- #37 

## 💡 구현 내용 요약
- 메일 발송 기능을 위한 Service 클래스와 DTO, 템플릿 구현

## ✅ 작업 상세 내용
- [Feat: 지원 수신 알림 메일 템플릿 구현](https://github.com/prgrms-be-devcourse/NBE5-7-2-Team10/commit/c8ed36cffd13a4ff34ac2e7c913c05c339268883)
타임리프로 템플릿 구현했습니다.

- [Feat: 메일 Service 구현](https://github.com/prgrms-be-devcourse/NBE5-7-2-Team10/commit/507e13293be9f1a8d36b3f6afe77a3087a19616e)
메일 전송 기능을 비동기로 구현했습니다.

## 📸 스크린샷
지원 신청 알림 메일 템플릿
![image](https://github.com/user-attachments/assets/9661ff5e-a44c-4041-99d2-d42d62d60400)

## 📎 기타 참고 사항
- 메일 전송 테스트는 이후 그린메일 사용해서 진행할 예정입니다.
- 아직 매칭 성사 기능이 구현되지 않아, 매칭 성사 알림 메일은 추후 개발 예정입니다.