### PR TITLE
Feat(FE): 로그인 기능 적용

### DIFF
--- a/backend/src/main/java/kr/co/programmers/collabond/api/user/application/UserService.java
+++ b/backend/src/main/java/kr/co/programmers/collabond/api/user/application/UserService.java
@@ -34,11 +34,11 @@ public class UserService {
     }
 
     @Transactional
-    public UserResponseDto update(Long userId, UserRequestDto dto) {
-        User user = userRepository.findById(userId)
+    public UserResponseDto update(String providerId, UserRequestDto dto) {
+        User user = userRepository.findByProviderId(providerId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 유저가 존재하지 않습니다."));
 
-        user.update(dto.getEmail(), dto.getNickname(), Role.valueOf(dto.getRole()));
+        user.update(null, dto.getNickname(), Role.valueOf(dto.getRole()));
         return UserMapper.toResponseDto(userRepository.save(user));
     }
 

--- a/backend/src/main/java/kr/co/programmers/collabond/api/user/domain/dto/UserRequestDto.java
+++ b/backend/src/main/java/kr/co/programmers/collabond/api/user/domain/dto/UserRequestDto.java
@@ -9,7 +9,6 @@ import lombok.*;
 @AllArgsConstructor
 @Builder
 public class UserRequestDto {
-    private String email;
     private String nickname;
     private String role;
 }

--- a/backend/src/main/java/kr/co/programmers/collabond/api/user/interfaces/UserController.java
+++ b/backend/src/main/java/kr/co/programmers/collabond/api/user/interfaces/UserController.java
@@ -3,8 +3,10 @@ package kr.co.programmers.collabond.api.user.interfaces;
 import kr.co.programmers.collabond.api.user.application.UserService;
 import kr.co.programmers.collabond.api.user.domain.dto.UserRequestDto;
 import kr.co.programmers.collabond.api.user.domain.dto.UserResponseDto;
+import kr.co.programmers.collabond.core.auth.oauth2.OAuth2UserInfo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -26,10 +28,10 @@ public class UserController {
                 .orElse(ResponseEntity.notFound().build());
     }
 
-    @PatchMapping("/{userId}")
-    public ResponseEntity<UserResponseDto> update(@PathVariable Long userId,
+    @PatchMapping
+    public ResponseEntity<UserResponseDto> update(@AuthenticationPrincipal OAuth2UserInfo userInfo,
                                                   @RequestBody UserRequestDto dto) {
-        return ResponseEntity.ok(userService.update(userId, dto));
+        return ResponseEntity.ok(userService.update(userInfo.getUsername(), dto));
     }
 
     @DeleteMapping("/{userId}")

--- a/backend/src/main/java/kr/co/programmers/collabond/api/user/interfaces/UserMapper.java
+++ b/backend/src/main/java/kr/co/programmers/collabond/api/user/interfaces/UserMapper.java
@@ -10,7 +10,6 @@ public class UserMapper {
 
     public static User toEntity(UserRequestDto dto) {
         return User.builder()
-                .email(dto.getEmail())
                 .nickname(dto.getNickname())
                 .role(Role.valueOf(dto.getRole()))
                 .build();

--- a/backend/src/main/java/kr/co/programmers/collabond/core/auth/jwt/LoginTokenResponseDto.java
+++ b/backend/src/main/java/kr/co/programmers/collabond/core/auth/jwt/LoginTokenResponseDto.java
@@ -1,3 +1,12 @@
 package kr.co.programmers.collabond.core.auth.jwt;
 
-public record LoginTokenResponseDto(String accessToken, String refreshToken) { }
+import kr.co.programmers.collabond.api.user.domain.Role;
+import lombok.Builder;
+
+@Builder
+public record LoginTokenResponseDto(
+        String accessToken,
+        String refreshToken,
+        Long id,
+        String nickname,
+        Role role) { }

--- a/backend/src/main/java/kr/co/programmers/collabond/core/auth/jwt/TokenMapper.java
+++ b/backend/src/main/java/kr/co/programmers/collabond/core/auth/jwt/TokenMapper.java
@@ -1,12 +1,24 @@
 package kr.co.programmers.collabond.core.auth.jwt;
 
 import kr.co.programmers.collabond.api.user.domain.Role;
+import kr.co.programmers.collabond.api.user.domain.User;
 
 public class TokenMapper {
     public static TokenBodyDto toTokenBodyDto(String sub, String role) {
         return TokenBodyDto.builder()
                 .providerId(sub)
                 .role(Role.valueOf(role.toUpperCase()))
+                .build();
+    }
+
+    public static LoginTokenResponseDto toLoginTokenResponseDto(
+            String accessToken, String refreshToken, User user) {
+        return LoginTokenResponseDto.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .id(user.getId())
+                .nickname(user.getNickname())
+                .role(user.getRole())
                 .build();
     }
 }

--- a/backend/src/main/java/kr/co/programmers/collabond/core/auth/jwt/TokenService.java
+++ b/backend/src/main/java/kr/co/programmers/collabond/core/auth/jwt/TokenService.java
@@ -54,7 +54,8 @@ public class TokenService {
                 .findByUserAndStatus(found, TokenStatus.VALID);
 
         if(foundRefreshToken.isPresent()) {
-            return new LoginTokenResponseDto(accessToken, foundRefreshToken.get().getToken());
+            return TokenMapper.toLoginTokenResponseDto(accessToken,
+                    foundRefreshToken.get().getToken(), found);
         }
 
         String refreshToken = createRefreshToken(providerId, role);
@@ -66,7 +67,7 @@ public class TokenService {
                 .build();
         refreshTokenRepository.save(newRefreshToken);
 
-        return new LoginTokenResponseDto(accessToken, refreshToken);
+        return TokenMapper.toLoginTokenResponseDto(accessToken, refreshToken, found);
     }
 
     public String createAccessToken(String providerId, Role role) {
@@ -104,7 +105,7 @@ public class TokenService {
         if (!validate(refreshToken)) {
             token.updateStatus(TokenStatus.EXPIRED);
             refreshTokenRepository.save(token);
-            throw new ExpiredException(ErrorCode.EXPIRED_TOKEN);
+            throw new ExpiredException(ErrorCode.EXPIRED_REFRESH_TOKEN);
         }
 
         // 토큰 페이로드 파싱

--- a/backend/src/main/java/kr/co/programmers/collabond/shared/exception/ApiExceptionHandler.java
+++ b/backend/src/main/java/kr/co/programmers/collabond/shared/exception/ApiExceptionHandler.java
@@ -1,6 +1,7 @@
 package kr.co.programmers.collabond.shared.exception;
 
 import kr.co.programmers.collabond.shared.exception.custom.DuplicatedException;
+import kr.co.programmers.collabond.shared.exception.custom.InvalidException;
 import kr.co.programmers.collabond.shared.exception.custom.NotFoundException;
 import kr.co.programmers.collabond.shared.util.ApiErrorResponse;
 import org.springframework.http.ResponseEntity;
@@ -28,6 +29,13 @@ public class ApiExceptionHandler {
     @ExceptionHandler({NotFoundException.class})
     public <T> ResponseEntity<ApiErrorResponse<T>> handleNotFoundException(
             NotFoundException exception
+    ) {
+        return ApiErrorResponse.error(exception.getMessage(), exception.getErrorCode());
+    }
+
+    @ExceptionHandler({InvalidException.class})
+    public <T> ResponseEntity<ApiErrorResponse<T>> handleInvalidException(
+            InvalidException exception
     ) {
         return ApiErrorResponse.error(exception.getMessage(), exception.getErrorCode());
     }

--- a/backend/src/main/java/kr/co/programmers/collabond/shared/exception/ErrorCode.java
+++ b/backend/src/main/java/kr/co/programmers/collabond/shared/exception/ErrorCode.java
@@ -16,6 +16,7 @@ public enum ErrorCode {
     DUPLICATED_USER_EMAIL(400, "이미 가입된 이메일입니다"),
     EXPIRED_DATA(401, "만료된 데이터입니다"),
     EXPIRED_TOKEN(401, "만료된 토큰입니다"),
+    EXPIRED_REFRESH_TOKEN(410, "만료된 리프레시 토큰입니다"),
     NOT_FOUND(404, "요청에 대한 데이터를 찾을 수 없습니다"),
     RECRUIT_NOT_FOUND(404, "모집 공고글을 찾을 수 없습니다"),
     PROFILE_NOT_FOUND(404, "프로필을 찾을 수 없습니다"),

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -85,8 +85,7 @@ custom:
       access: 600 # 10분
       refresh: 604800 # 7일
     secret: 76a6057b59bd44c7a87bbaa0576dae0376a6057b59bd44c7a87bbaa0576dae0376a6057b59bd44c7a87bbaa0576dae03
-    redirect-main: http://localhost:3000/oauth
-    redirect-sign-up: http://localhost:3000/signup
+    redirect-login-success: ${custom.cors.allowed-origin}/auth/callback
   mail:
     subject:
       apply-received: '[Collabond] 새로운 지원자가 있습니다!'

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,31 +1,32 @@
-"use client"
-import { useState, useEffect } from "react"
-import { BrowserRouter as Router, Routes, Route } from "react-router-dom"
-import Header from "./components/Header"
-import MainPage from "./pages/MainPage"
-import MyPage from "./pages/MyPage"
-import RecruitmentListPage from "./pages/RecruitmentListPage"
-import RecruitmentCreatePage from "./pages/RecruitmentCreatePage"
-import RecruitmentEditPage from "./pages/RecruitmentEditPage"
-import UserTypeSelectionPage from "./pages/UserTypeSelectionPage"
-import AdminPage from "./pages/AdminPage"
-import LoginPage from "./pages/LoginPage"
-import { AuthProvider } from "./contexts/AuthContext"
-import ProtectedRoute from "./components/ProtectedRoute"
-import "./App.css"
+"use client";
+import { useState, useEffect } from "react";
+import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
+import Header from "./components/Header";
+import MainPage from "./pages/MainPage";
+import MyPage from "./pages/MyPage";
+import RecruitmentListPage from "./pages/RecruitmentListPage";
+import RecruitmentCreatePage from "./pages/RecruitmentCreatePage";
+import RecruitmentEditPage from "./pages/RecruitmentEditPage";
+import UserTypeSelectionPage from "./pages/UserTypeSelectionPage";
+import AdminPage from "./pages/AdminPage";
+import LoginPage from "./pages/LoginPage";
+import LoginCallback from "./pages/LoginCallback";
+import { AuthProvider } from "./contexts/AuthContext";
+import ProtectedRoute from "./components/ProtectedRoute";
+import "./App.css";
 
 function App() {
   // 클라이언트 사이드에서만 렌더링하기 위한 상태
-  const [isMounted, setIsMounted] = useState(false)
+  const [isMounted, setIsMounted] = useState(false);
 
   useEffect(() => {
     // 즉시 마운트 상태를 true로 설정하여 컴포넌트가 바로 렌더링되도록 합니다
-    setIsMounted(true)
-  }, [])
+    setIsMounted(true);
+  }, []);
 
   // 서버 사이드 렌더링 시 빈 div 반환
   if (!isMounted) {
-    return <div></div>
+    return <div></div>;
   }
 
   return (
@@ -37,7 +38,8 @@ function App() {
             <Routes>
               <Route path="/" element={<MainPage />} />
               <Route path="/login" element={<LoginPage />} />
-              <Route path="/user-type-selection" element={<UserTypeSelectionPage />} />
+              <Route path="/auth/callback" element={<LoginCallback />} />
+              <Route path="/signup" element={<UserTypeSelectionPage />} />
               <Route path="/recruitment" element={<RecruitmentListPage />} />
               <Route
                 path="/recruitment/create"
@@ -76,7 +78,7 @@ function App() {
         </div>
       </Router>
     </AuthProvider>
-  )
+  );
 }
 
-export default App
+export default App;

--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -1,113 +1,143 @@
-"use client"
+"use client";
 
-import axios from "axios"
+import axios from "axios";
+import {
+  getAccessToken,
+  getRefreshToken,
+  setTokens,
+  setAccessToken,
+  clearTokens,
+} from "../utils/storage";
 
-const BASE_URL = process.env.REACT_APP_API_URL || "http://localhost:8080/api"
+const BASE_URL = "http://localhost:8080";
 
 // 브라우저 환경인지 확인
-const isBrowser = typeof window !== "undefined"
+const isBrowser = typeof window !== "undefined";
 
 export const api = axios.create({
   baseURL: BASE_URL,
   headers: {
     "Content-Type": "application/json",
   },
-})
+});
 
 // 브라우저 환경에서만 토큰 처리
 if (isBrowser) {
-  // Add a request interceptor to include the auth token
-  api.interceptors.request.use(
-    (config) => {
-      const token = localStorage.getItem("token")
-      if (token) {
-        config.headers.Authorization = `Bearer ${token}`
-      }
-      return config
-    },
-    (error) => {
-      return Promise.reject(error)
-    },
-  )
+  api.interceptors.request.use((config) => {
+    const token = getAccessToken();
+    if (token) {
+      config.headers.Authorization = `Bearer ${token}`;
+    }
+    return config;
+  });
 
   // Add a response interceptor to handle common errors
   api.interceptors.response.use(
-    (response) => {
-      return response
-    },
-    (error) => {
-      if (error.response && error.response.status === 401) {
-        // Unauthorized, clear token and redirect to login
-        localStorage.removeItem("token")
-        window.location.href = "/login"
+    (response) => response,
+    async (error) => {
+      const original = error.config;
+      // 응답 코드가 401이면 엑세스 토큰 재발급
+      if (error.response?.status === 401 && !original._retry) {
+        original._retry = true;
+        const refreshToken = getRefreshToken();
+        // 리프레시 토큰이 없으면 로그아웃 처리
+        if (!refreshToken) {
+          clearTokens();
+          window.location.href = "/login";
+          return Promise.reject(error);
+        }
+        // 재발급 요청
+        const { data } = await axios.post(`${BASE_URL}/api/tokens/refresh`, {
+          refreshToken,
+        });
+        setAccessToken({
+          accessToken: data.accessToken,
+        });
+        // 교체된 토큰으로 원 요청 재시도
+        original.headers.Authorization = `Bearer ${data.accessToken}`;
+        return api(original);
       }
-      return Promise.reject(error)
-    },
-  )
+
+      // 응답 코드가 410이면 리프레시 토큰 만료로 로그아웃 처리
+      if (error.response?.status === 410) {
+        clearTokens();
+        window.location.href = "/login";
+      }
+      return Promise.reject(error);
+    }
+  );
 }
 
 // Auth API
 export const authAPI = {
-  login: (code) => api.post("/auth/login", { code }),
-  signup: (userData) => api.post("/auth/signup", userData),
-}
+  login: (code) => api.post("/api/auth/login", { code }),
+  signup: (userData) => api.post("/api/auth/signup", userData),
+};
 
 // User API
 export const userAPI = {
-  getProfile: (userId) => api.get(`/users/${userId}`),
-  updateProfile: (userId, data) => api.patch(`/users/${userId}`, data),
-  deleteAccount: (userId) => api.delete(`/users/${userId}`),
-  getUserProfiles: (userId) => api.get(`/users/${userId}/profiles`),
-}
+  getProfile: (userId) => api.get(`/api/users/${userId}`),
+  updateProfile: (data) => api.patch(`/api/users`, data),
+  deleteAccount: (userId) => api.delete(`/api/users/${userId}`),
+  getUserProfiles: (userId) => api.get(`/api/users/${userId}/profiles`),
+};
 
 // Profile API
 export const profileAPI = {
-  createProfile: (data) => api.post("/profiles", data),
-  getProfile: (profileId) => api.get(`/profiles/${profileId}`),
-  updateProfile: (profileId, data) => api.patch(`/profiles/${profileId}`, data),
-  deleteProfile: (profileId) => api.delete(`/profiles/${profileId}`),
-  getIPProfiles: (params) => api.get("/profiles/ip", { params }),
-  getStoreProfiles: (params) => api.get("/profiles/store", { params }),
-}
+  createProfile: (data) => api.post("/api/profiles", data),
+  getProfile: (profileId) => api.get(`/api/profiles/${profileId}`),
+  updateProfile: (profileId, data) =>
+    api.patch(`/api/profiles/${profileId}`, data),
+  deleteProfile: (profileId) => api.delete(`/api/profiles/${profileId}`),
+  getIPProfiles: (params) => api.get("/api/profiles/ip", { params }),
+  getStoreProfiles: (params) => api.get("/api/profiles/store", { params }),
+};
 
 // Recruitment API
 export const recruitmentAPI = {
-  createRecruitment: (data) => api.post("/recruitments", data),
-  getRecruitment: (id) => api.get(`/recruitments/${id}`),
-  updateRecruitment: (id, data) => api.patch(`/recruitments/${id}`, data),
-  deleteRecruitment: (id) => api.delete(`/recruitments/${id}`),
-  getRecruitments: (params) => api.get("/recruitments", { params }),
-  getUserRecruitments: (userId) => api.get(`/recruitments/users/${userId}`),
-  getProfileRecruitments: (profileId) => api.get(`/recruitments/profiles/${profileId}`),
-}
+  createRecruitment: (data) => api.post("/api/recruitments", data),
+  getRecruitment: (id) => api.get(`/api/recruitments/${id}`),
+  updateRecruitment: (id, data) => api.patch(`/api/recruitments/${id}`, data),
+  deleteRecruitment: (id) => api.delete(`/api/recruitments/${id}`),
+  getRecruitments: (params) => api.get("/api/recruitments", { params }),
+  getUserRecruitments: (userId) => api.get(`/api/recruitments/users/${userId}`),
+  getProfileRecruitments: (profileId) =>
+    api.get(`/api/recruitments/profiles/${profileId}`),
+};
 
 // Application API
 export const applicationAPI = {
-  applyToRecruitment: (recruitmentId, data) => api.post(`/applications/${recruitmentId}`, data),
-  getSentApplications: (params) => api.get("/applications/sent", { params }),
-  getReceivedApplications: (params) => api.get("/applications/received", { params }),
-  acceptApplication: (applicationId) => api.patch(`/applications/accept/${applicationId}`),
-}
+  applyToRecruitment: (recruitmentId, data) =>
+    api.post(`/api/applications/${recruitmentId}`, data),
+  getSentApplications: (params) =>
+    api.get("/api/applications/sent", { params }),
+  getReceivedApplications: (params) =>
+    api.get("/api/applications/received", { params }),
+  acceptApplication: (applicationId) =>
+    api.patch(`/api/applications/accept/${applicationId}`),
+};
 
 // Admin API
 export const adminAPI = {
-  createTag: (data) => api.post("/admin/tags", data),
-  deleteTag: (tagId) => api.delete(`/admin/tags/${tagId}`),
-  getAllUsers: () => api.get("/admin/users"),
-  deleteUser: (userId) => api.delete(`/admin/users/${userId}`),
-}
+  createTag: (data) => api.post("/api/admin/tags", data),
+  deleteTag: (tagId) => api.delete(`/api/admin/tags/${tagId}`),
+  getAllUsers: () => api.get("/api/admin/users"),
+  deleteUser: (userId) => api.delete(`/api/admin/users/${userId}`),
+};
 
 // Tag API
 export const tagAPI = {
-  getAllTags: () => api.get("/tags"),
-  getIPTags: () => api.get("/tags?type=IP"),
-  getStoreTags: () => api.get("/tags?type=STORE"),
-}
+  getAllTags: () => api.get("/api/tags"),
+  getIPTags: () => api.get("/api/tags?type=IP"),
+  getStoreTags: () => api.get("/api/tags?type=STORE"),
+};
 
 // Region API
 export const regionAPI = {
-  getAllRegions: () => api.get("/regions"),
-  getProvinces: () => api.get("/regions/provinces"),
-  getDistricts: (provinceId) => api.get(`/regions/districts?provinceId=${provinceId}`),
-  getNeighborhoods: (districtId) => api.get(`/regions/neighborhoods?districtId=${districtId}`),
-}
+  getAllRegions: () => api.get("/api/regions"),
+  getProvinces: () => api.get("/api/regions/provinces"),
+  getDistricts: (provinceId) =>
+    api.get(`/api/regions/districts?provinceId=${provinceId}`),
+  getNeighborhoods: (districtId) =>
+    api.get(`/api/regions/neighborhoods?districtId=${districtId}`),
+};

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -3,11 +3,13 @@
 import { useState, useContext } from "react"
 import { Link, useNavigate } from "react-router-dom"
 import { AuthContext } from "../contexts/AuthContext"
+import { getUserInfo, isSignedIn } from '../utils/storage'
 import LoginModal from "./LoginModal"
 import "./Header.css"
 
 const Header = () => {
-  const { user, logout } = useContext(AuthContext)
+  const { logout } = useContext(AuthContext)
+  const user = getUserInfo();
   const navigate = useNavigate()
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
   const [showLoginModal, setShowLoginModal] = useState(false)
@@ -52,7 +54,7 @@ const Header = () => {
                 모집 게시판
               </Link>
             </li>
-            {user ? (
+            {isSignedIn() ? (
               <>
                 {user.role === "ROLE_ADMIN" && (
                   <li>

--- a/frontend/src/components/LoginModal.jsx
+++ b/frontend/src/components/LoginModal.jsx
@@ -1,31 +1,10 @@
 "use client"
-import { useContext } from "react"
-import { AuthContext } from "../contexts/AuthContext"
 import "./LoginModal.css"
 
 const LoginModal = ({ onClose }) => {
-  const { login } = useContext(AuthContext)
 
-  const handleSocialLogin = async (provider) => {
-    try {
-      // 실제 구현에서는 OAuth 인증 과정을 거쳐야 합니다
-      // 여기서는 간단히 모의 코드로 구현합니다
-      const mockOAuthCode = `mock_${provider}_oauth_code_${Date.now()}`
-      const result = await login(mockOAuthCode)
-
-      if (result.isNewUser) {
-        // 새 사용자인 경우 유형 선택 페이지로 이동
-        window.location.href = "/user-type-selection"
-      } else {
-        // 기존 사용자인 경우 홈으로 이동
-        window.location.href = "/"
-      }
-
-      onClose()
-    } catch (error) {
-      console.error(`${provider} 로그인 오류:`, error)
-      alert(`${provider} 로그인에 실패했습니다.`)
-    }
+  const handleSocialLogin = (provider) => {
+    window.location.href = `http://localhost:8080/oauth2/authorization/${provider}`
   }
 
   return (

--- a/frontend/src/components/ProtectedRoute.jsx
+++ b/frontend/src/components/ProtectedRoute.jsx
@@ -2,10 +2,10 @@
 
 import { useContext, useEffect, useState } from "react"
 import { Navigate } from "react-router-dom"
-import { AuthContext } from "../contexts/AuthContext"
+import { getUserInfo } from '../utils/storage'
 
 const ProtectedRoute = ({ children, adminOnly = false }) => {
-  const { user, loading } = useContext(AuthContext)
+
   const [isMounted, setIsMounted] = useState(false)
 
   useEffect(() => {
@@ -13,15 +13,17 @@ const ProtectedRoute = ({ children, adminOnly = false }) => {
   }, [])
 
   // 서버 사이드 렌더링 시 또는 로딩 중일 때 로딩 표시
-  if (!isMounted || loading) {
+  if (!isMounted) {
     return <div className="loading">로딩 중...</div>
   }
 
-  if (!user) {
+  const userInfo = getUserInfo();
+
+  if (!userInfo) {
     return <Navigate to="/login" />
   }
 
-  if (adminOnly && user.role !== "ROLE_ADMIN") {
+  if (adminOnly && userInfo.role !== "ROLE_ADMIN") {
     return <Navigate to="/" />
   }
 

--- a/frontend/src/contexts/AuthContext.jsx
+++ b/frontend/src/contexts/AuthContext.jsx
@@ -1,79 +1,31 @@
 "use client"
 
-import { createContext, useState, useEffect } from "react"
-import { api } from "../api"
+// src/context/AuthContext.js
+import { createContext, useState, useEffect } from 'react';
+import { clearTokens, setTokens, isSignedUp, getUserInfo, isSignedIn } from '../utils/storage';
 
-// 초기 상태 정의
-const initialState = {
-  user: null,
-  loading: true,
-  login: () => Promise.resolve({ isNewUser: false }),
-  logout: () => {},
-  updateUser: () => {},
-}
-
-export const AuthContext = createContext(initialState)
+export const AuthContext = createContext();
 
 export const AuthProvider = ({ children }) => {
-  const [user, setUser] = useState(null)
-  const [loading, setLoading] = useState(true)
-  const [isBrowser, setIsBrowser] = useState(false)
+  const login = ({ accessToken, refreshToken, userId, nickname, role }) => {
+    setTokens({ accessToken, refreshToken, userId, nickname, role });
 
-  // 클라이언트 사이드에서만 실행되도록 설정
-  useEffect(() => {
-    // 즉시 브라우저 환경으로 설정
-    setIsBrowser(true)
-
-    // Check if user is already logged in
-    const checkAuth = async () => {
-      try {
-        const token = localStorage.getItem("token")
-        if (token) {
-          // Validate token and get user info
-          const response = await api.get("/users/me")
-          setUser(response.data)
-        }
-      } catch (error) {
-        console.error("Authentication error:", error)
-        localStorage.removeItem("token")
-      } finally {
-        setLoading(false)
-      }
+    if(!isSignedUp()) {
+      window.location.href = '/signup';
+      return;
     }
 
-    checkAuth()
-  }, [])
-
-  const login = async (code) => {
-    try {
-      const response = await api.post("/auth/login", { code })
-      const { token, user } = response.data
-
-      localStorage.setItem("token", token)
-      setUser(user)
-
-      return { isNewUser: user.isNewUser }
-    } catch (error) {
-      console.error("Login error:", error)
-      throw error
-    }
-  }
+    window.location.href = '/';
+  };
 
   const logout = () => {
-    if (isBrowser) {
-      localStorage.removeItem("token")
-    }
-    setUser(null)
-  }
+    clearTokens();
+    window.location.href = '/login';
+  };
 
-  const updateUser = (updatedUser) => {
-    setUser((prevUser) => ({ ...prevUser, ...updatedUser }))
-  }
-
-  // 서버 사이드 렌더링 시 초기 상태 반환
-  if (!isBrowser) {
-    return <AuthContext.Provider value={initialState}>{children}</AuthContext.Provider>
-  }
-
-  return <AuthContext.Provider value={{ user, loading, login, logout, updateUser }}>{children}</AuthContext.Provider>
-}
+  return (
+    <AuthContext.Provider value={{ login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};

--- a/frontend/src/pages/LoginCallback.jsx
+++ b/frontend/src/pages/LoginCallback.jsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useEffect, useContext } from "react";
+import { useRouter } from "next/navigation";
+import { AuthContext } from "../contexts/AuthContext";
+import { useSearchParams } from 'react-router-dom';
+
+export default function OAuthCallback() {
+  const router = useRouter();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const { login } = useContext(AuthContext);
+
+  useEffect(() => {
+    // 예: ?accessToken=…&refreshToken=…&userId=…&nickname=…&role=…
+    const accessToken = searchParams.get('accessToken');
+    const refreshToken = searchParams.get('refreshToken');
+    const userId = searchParams.get('userId');
+    const nickname = searchParams.get('nickname');
+    const role = searchParams.get('role');
+
+    // 토큰이 제대로 넘어왔으면 로그인 처리
+    if (accessToken && refreshToken) {
+      login({ accessToken, refreshToken, userId, nickname, role });
+    } else {
+      // 실패 시 로그인 화면으로 리다이렉트
+      router.replace("/login?error=oauth_failed");
+    }
+  }, []);
+
+  return <p>로그인 처리 중…</p>;
+}

--- a/frontend/src/pages/MyPage.jsx
+++ b/frontend/src/pages/MyPage.jsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useContext } from "react"
 import { Routes, Route, useNavigate, useLocation } from "react-router-dom"
-import { AuthContext } from "../contexts/AuthContext"
+import { getUserInfo } from "../utils/storage"
 import UserInfo from "../components/mypage/UserInfo"
 import ProfileEdit from "../components/mypage/ProfileEdit"
 import ReceivedApplications from "../components/mypage/ReceivedApplications"
@@ -11,7 +11,7 @@ import MyRecruitments from "../components/mypage/MyRecruitments"
 import "./MyPage.css"
 
 const MyPage = () => {
-  const { user } = useContext(AuthContext)
+  const user = getUserInfo()
   const navigate = useNavigate()
   const location = useLocation()
   const [activeTab, setActiveTab] = useState("profile")

--- a/frontend/src/pages/RecruitmentCreatePage.jsx
+++ b/frontend/src/pages/RecruitmentCreatePage.jsx
@@ -4,10 +4,11 @@ import { useState, useEffect, useContext } from "react"
 import { useNavigate } from "react-router-dom"
 import { AuthContext } from "../contexts/AuthContext"
 import { recruitmentAPI, profileAPI } from "../api"
+import { getUserInfo } from "../utils/storage"
 import "./RecruitmentCreatePage.css"
 
 const RecruitmentCreatePage = () => {
-  const { user } = useContext(AuthContext)
+  const [user, setUser] = useState(getUserInfo())
   const navigate = useNavigate()
   const [userProfiles, setUserProfiles] = useState([])
   const [loading, setLoading] = useState(true)

--- a/frontend/src/pages/UserTypeSelectionPage.jsx
+++ b/frontend/src/pages/UserTypeSelectionPage.jsx
@@ -2,17 +2,15 @@
 
 import { useState, useContext } from "react"
 import { useNavigate } from "react-router-dom"
-import { AuthContext } from "../contexts/AuthContext"
 import { userAPI } from "../api"
+import { setNickname, setRole } from "../utils/storage"
 import "./UserTypeSelectionPage.css"
 
 const UserTypeSelectionPage = () => {
-  const { user, updateUser } = useContext(AuthContext)
   const navigate = useNavigate()
   const [formData, setFormData] = useState({
     role: "",
     nickname: "",
-    phoneNumber: "",
   })
   const [loading, setLoading] = useState(false)
 
@@ -42,15 +40,15 @@ const UserTypeSelectionPage = () => {
     try {
       setLoading(true)
 
-      const response = await userAPI.updateProfile(user.id, formData)
-
+      const response = await userAPI.updateProfile(formData)
+      setNickname(response.data.nickname);
+      setRole(response.data.role);
       // Update user context
-      updateUser(response.data)
-
+      
       navigate("/")
     } catch (error) {
-      console.error("Error updating user type:", error)
-      alert("사용자 유형 설정에 실패했습니다.")
+      console.error("Error updating user info:", error)
+      alert("회원가입에 실패했습니다.")
     } finally {
       setLoading(false)
     }
@@ -94,20 +92,6 @@ const UserTypeSelectionPage = () => {
           </div>
 
           <form onSubmit={handleSubmit} className="user-form">
-            <div className="form-group">
-              <label htmlFor="phoneNumber">전화번호</label>
-              <input
-                type="tel"
-                id="phoneNumber"
-                name="phoneNumber"
-                value={formData.phoneNumber}
-                onChange={handleChange}
-                className="form-control"
-                placeholder="전화번호를 입력해주세요"
-                required
-              />
-            </div>
-
             <div className="form-group">
               <label htmlFor="nickname">닉네임</label>
               <input

--- a/frontend/src/utils/storage.js
+++ b/frontend/src/utils/storage.js
@@ -1,0 +1,80 @@
+// src/utils/storage.js
+const TOKEN_KEY = {
+  ACCESS: "access_token",
+  REFRESH: "refresh_token",
+  USER_ID: "userId",
+  NICKNAME: "nickname",
+  ROLE: "role",
+};
+
+export const getAccessToken = () => localStorage.getItem(TOKEN_KEY.ACCESS);
+
+export const getRefreshToken = () => localStorage.getItem(TOKEN_KEY.REFRESH);
+
+export const getUserId = () => localStorage.getItem(TOKEN_KEY.USER_ID);
+
+export const getNickname = () => localStorage.getItem(TOKEN_KEY.NICKNAME);
+
+export const getRole = () => localStorage.getItem(TOKEN_KEY.ROLE);
+
+export const getUserInfo = () => {
+  const accessToken = localStorage.getItem(TOKEN_KEY.ROLE);
+  const refreshToken = localStorage.getItem(TOKEN_KEY.REFRESH);
+  const userId = localStorage.getItem(TOKEN_KEY.USER_ID);
+  const nickname = localStorage.getItem(TOKEN_KEY.NICKNAME);
+  const role = localStorage.getItem(TOKEN_KEY.ROLE);
+
+  return { accessToken, refreshToken, userId, nickname, role };
+};
+
+export const isSignedIn = () => {
+  const refreshToken = localStorage.getItem(TOKEN_KEY.REFRESH);
+  if (refreshToken !== null) {
+    return true;
+  }
+
+  return false;
+};
+
+export const isSignedUp = () => {
+  const role = localStorage.getItem(TOKEN_KEY.ROLE);
+  if (role !== null && role !== "ROLE_TMP") {
+    return true;
+  }
+
+  return false;
+};
+
+export const setTokens = ({
+  accessToken,
+  refreshToken,
+  userId,
+  nickname,
+  role,
+}) => {
+  localStorage.setItem(TOKEN_KEY.ACCESS, accessToken);
+  localStorage.setItem(TOKEN_KEY.REFRESH, refreshToken);
+  localStorage.setItem(TOKEN_KEY.USER_ID, userId);
+  localStorage.setItem(TOKEN_KEY.NICKNAME, nickname);
+  localStorage.setItem(TOKEN_KEY.ROLE, role);
+};
+
+export const setAccessToken = ({ accessToken }) => {
+  localStorage.setItem(TOKEN_KEY.ACCESS, accessToken);
+};
+
+export const setNickname = (nickname) => {
+  localStorage.setItem(TOKEN_KEY.NICKNAME, nickname);
+};
+
+export const setRole = (role) => {
+  localStorage.setItem(TOKEN_KEY.ROLE, role);
+};
+
+export const clearTokens = () => {
+  localStorage.removeItem(TOKEN_KEY.ACCESS);
+  localStorage.removeItem(TOKEN_KEY.REFRESH);
+  localStorage.removeItem(TOKEN_KEY.USER_ID);
+  localStorage.removeItem(TOKEN_KEY.NICKNAME);
+  localStorage.removeItem(TOKEN_KEY.ROLE);
+};


### PR DESCRIPTION
## 📌 관련 이슈
- #50 

## 💡 구현 내용 요약
- 프론트엔드에 로그인, 회원 가입 및 토큰 관리 기능을 구현했습니다.

## ✅ 작업 상세 내용
- 프론트엔드와 설정을 맞추기 위해 백엔드의 redirect 주소 등을 수정하였습니다.
- 프론트엔드에서 회원 정보 및 토큰을 관리하는 storage 기능을 추가했습니다.
- 프론트엔드에 토큰 관련 기능을 수행하기 위한 인터셉터 기능을 구현했습니다.
  - 프론트엔드에서 토큰 만료 상태 코드(401)를 응답받을 시, 보유하고 있는 리프레시 토큰으로 엑세스 토큰을 재발급 받게 했습니다.
  - 모든 요청에 엑세스 토큰이 있을 경우, 헤더에 추가하여 요청하도록 했습니다.
- 회원가입에 필요 없는 항목을 프론트와 백엔드에서 모두 제거했습니다.