### PR TITLE
Refactor: 프로필 주소 기입 방식 등 수정#87

### DIFF
--- a/backend/src/main/java/kr/co/programmers/collabond/api/profile/application/ProfileService.java
+++ b/backend/src/main/java/kr/co/programmers/collabond/api/profile/application/ProfileService.java
@@ -101,7 +101,7 @@ public class ProfileService {
         Profile profile = profileRepository.findById(profileId)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.PROFILE_NOT_FOUND));
 
-        profile.update(dto.getName(), dto.getDescription(), dto.getAddressCode(), dto.getAddress());
+        profile.update(dto.getName(), dto.getDescription(), dto.getAddressCode(), dto.getAddress(), dto.isStatus());//활성/비활성 업데이트
 
         updateImage(profile, profileImage, "PROFILE");
         updateImage(profile, thumbnailImage, "THUMBNAIL");

--- a/backend/src/main/java/kr/co/programmers/collabond/api/profile/domain/Profile.java
+++ b/backend/src/main/java/kr/co/programmers/collabond/api/profile/domain/Profile.java
@@ -106,7 +106,7 @@ public class Profile extends UpdatedEntity {
         return Boolean.TRUE.equals(this.status);
     }
 
-    public void update(String name, String description, String addressCode, String address) {
+    public void update(String name, String description, String addressCode, String address, boolean status) {
         if (name != null) {
             this.name = name;
         }
@@ -122,6 +122,7 @@ public class Profile extends UpdatedEntity {
         if(address != null){
             this.address = address;
         }
+        this.status = status;
     }
 
     public void addImage(Image image) {

--- a/backend/src/main/java/kr/co/programmers/collabond/api/profile/domain/dto/ProfileRequestDto.java
+++ b/backend/src/main/java/kr/co/programmers/collabond/api/profile/domain/dto/ProfileRequestDto.java
@@ -15,5 +15,8 @@ public class ProfileRequestDto {
     private String description;
     private String address;
     private String addressCode;
+    private boolean status;
     private List<Long> tagIds;
+
+
 }

--- a/backend/src/main/java/kr/co/programmers/collabond/api/profile/domain/dto/ProfileSimpleResponseDto.java
+++ b/backend/src/main/java/kr/co/programmers/collabond/api/profile/domain/dto/ProfileSimpleResponseDto.java
@@ -11,5 +11,6 @@ public class ProfileSimpleResponseDto {
     private String type;
     private String imageUrl;
     private String address;
+    private boolean status;
 }
 

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -29,6 +29,7 @@ INSERT INTO tags (id, name, type, created_at) VALUES (7, '천진난만', 'IP', N
 INSERT INTO tags (id, name, type, created_at) VALUES (8, '병맛', 'IP', NOW());
 INSERT INTO tags (id, name, type, created_at) VALUES (9, '웃긴', 'IP', NOW());
 INSERT INTO tags (id, name, type, created_at) VALUES (10, '깜찍뽀짝', 'IP', NOW());
+/*
 INSERT INTO profiles (id, user_id, address_code, address, type, name, description, collabo_count, status, created_at, updated_at) VALUES (1, 1, 11, '상세주소1', 'STORE', '매장프로필1', '설명1', 2, TRUE, NOW(), NOW());
 INSERT INTO profiles (id, user_id, address_code, address, type, name, description, collabo_count, status, created_at, updated_at) VALUES (2, 2, 11, '상세주소2', 'STORE', '매장프로필2', '설명2', 4, TRUE, NOW(), NOW());
 INSERT INTO profiles (id, user_id, address_code, address, type, name, description, collabo_count, status, created_at, updated_at) VALUES (3, 3, 11, '상세주소3', 'STORE', '매장프로필3', '설명3', 6, TRUE, NOW(), NOW());
@@ -69,3 +70,4 @@ INSERT INTO apply_posts (id, recruit_post_id, profile_id, content, status, creat
 INSERT INTO apply_posts (id, recruit_post_id, profile_id, content, status, created_at) VALUES (8, 8, 3, '지원내용8', 'PENDING', NOW());
 INSERT INTO apply_posts (id, recruit_post_id, profile_id, content, status, created_at) VALUES (9, 9, 4, '지원내용9', 'PENDING', NOW());
 INSERT INTO apply_posts (id, recruit_post_id, profile_id, content, status, created_at) VALUES (10, 10, 5, '지원내용10', 'PENDING', NOW());
+*/

--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -182,13 +182,38 @@ export const tagAPI = {
   getStoreTags: () => api.get("/api/tags?type=STORE"),
 };
 
-// Region API
+// // Region API
+// export const regionAPI = {
+//   getAddress: async (cd) => {
+//     const token = await getGovAccessToken();
+//     const res = await apiClient.get(
+//       `/addr/stage.json?accessToken=${token}${cd ? `&cd=${cd}` : ""}`
+//     );
+//     return res;
+//   },
+// };
+
 export const regionAPI = {
+  // 기존: 법정동 단계별 공통 엔드포인트
   getAddress: async (cd) => {
     const token = await getGovAccessToken();
-    const res = await apiClient.get(
+    return apiClient.get(
       `/addr/stage.json?accessToken=${token}${cd ? `&cd=${cd}` : ""}`
     );
-    return res;
+  },
+
+  // 1) 시/도 목록만: cd 없이 호출
+  getProvinces() {
+    return this.getAddress();
+  },
+
+  // 2) 시/군/구: 상위 코드 넘겨서 호출
+  getDistricts(cd) {
+    return this.getAddress(cd);
+  },
+
+  // 3) 읍/면/동: 상위 코드 넘겨서 호출
+  getNeighborhoods(cd) {
+    return this.getAddress(cd);
   },
 };

--- a/frontend/src/components/SingleRegionSelector.jsx
+++ b/frontend/src/components/SingleRegionSelector.jsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { regionAPI } from "../api";
+import "./RegionSelector.css";
+
+const SingleRegionSelector = ({ initialCode, onSelect }) => {
+  const [provinces, setProvinces] = useState([]);
+  const [districts, setDistricts] = useState([]);
+  const [neighborhoods, setNeighborhoods] = useState([]);
+
+  const [selectedProvince, setSelectedProvince] = useState(null);
+  const [selectedDistrict, setSelectedDistrict] = useState(null);
+  const [selectedNeighborhood, setSelectedNeighborhood] = useState(null);
+
+  // 1) 도/특별시 목록 불러오기
+  useEffect(() => {
+    const fetchProvinces = async () => {
+      const res = await regionAPI.getProvinces();
+      // res.data.result 안에 [{ cd, ctp_kor, … }, …] 형태로 내려옴
+      const items = (res.data.result || []).map((r) => ({
+        id: r.cd,                    // 내부 구분용
+        code: r.cd,                  // 법정동 코드
+        name: r.ctp_kor || r.ctp_nm, // 도/특별시 명
+      }));
+      setProvinces(items);
+    };
+    fetchProvinces();
+  }, []);
+
+  // 2) 시/군/구 목록 불러오기
+  useEffect(() => {
+    if (!selectedProvince) return;
+    const fetchDistricts = async () => {
+      const res = await regionAPI.getDistricts(selectedProvince.code);
+      const items = (res.data.result || []).map((r) => ({
+        id: r.cd,
+        code: r.cd,
+        name: r.sigungu_kor || r.sigungu_nm,
+      }));
+      setDistricts(items);
+      setSelectedDistrict(null);
+      setNeighborhoods([]);
+    };
+    fetchDistricts();
+  }, [selectedProvince]);
+
+  // 3) 읍/면/동 목록 불러오기
+  useEffect(() => {
+    if (!selectedDistrict) return;
+    const fetchNeighborhoods = async () => {
+      const res = await regionAPI.getNeighborhoods(selectedDistrict.code);
+      const items = (res.data.result || []).map((r) => ({
+        id: r.cd,
+        code: r.cd,
+        name: r.emd_kor || r.emd_nm,
+      }));
+      setNeighborhoods(items);
+      setSelectedNeighborhood(null);
+    };
+    fetchNeighborhoods();
+  }, [selectedDistrict]);
+
+  const handleFinalSelect = () => {
+    let code = "";
+    let fullAddress = "";
+
+    if (selectedNeighborhood) {
+      code = selectedNeighborhood.code;
+      fullAddress = `${selectedProvince.name} ${selectedDistrict.name} ${selectedNeighborhood.name}`;
+    } else if (selectedDistrict) {
+      code = selectedDistrict.code;
+      fullAddress = `${selectedProvince.name} ${selectedDistrict.name}`;
+    } else if (selectedProvince) {
+      code = selectedProvince.code;
+      fullAddress = selectedProvince.name;
+    }
+
+    if (code && fullAddress) {
+      // 부모가 expect 하는 shape: { code, fullAddress }
+      onSelect({ code, fullAddress });
+    }
+  };
+
+  return (
+    <div className="region-selector">
+      <label>지역 선택</label>
+      <div className="region-dropdowns">
+        <select
+          value={selectedProvince?.id || ""}
+          onChange={(e) =>
+            setSelectedProvince(
+              provinces.find((p) => p.id === e.target.value)
+            )
+          }
+        >
+          <option value="">시/도 선택</option>
+          {provinces.map((p) => (
+            <option key={p.id} value={p.id}>
+              {p.name}
+            </option>
+          ))}
+        </select>
+
+        <select
+          disabled={!selectedProvince}
+          value={selectedDistrict?.id || ""}
+          onChange={(e) =>
+            setSelectedDistrict(
+              districts.find((d) => d.id === e.target.value)
+            )
+          }
+        >
+          <option value="">시/군/구 선택</option>
+          {districts.map((d) => (
+            <option key={d.id} value={d.id}>
+              {d.name}
+            </option>
+          ))}
+        </select>
+
+        <select
+          disabled={!selectedDistrict}
+          value={selectedNeighborhood?.id || ""}
+          onChange={(e) =>
+            setSelectedNeighborhood(
+              neighborhoods.find((n) => n.id === e.target.value)
+            )
+          }
+        >
+          <option value="">읍/면/동 선택</option>
+          {neighborhoods.map((n) => (
+            <option key={n.id} value={n.id}>
+              {n.name}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <button
+        className="btn btn-primary mt-2"
+        type="button"
+        onClick={handleFinalSelect}
+      >
+        주소 선택
+      </button>
+    </div>
+  );
+};
+
+export default SingleRegionSelector;

--- a/frontend/src/components/mypage/ProfileCreateModal.css
+++ b/frontend/src/components/mypage/ProfileCreateModal.css
@@ -23,11 +23,14 @@
 }
 
 .image-preview {
-  width: 120px;
-  height: 120px;
+  width: 100px;    
+  height: 100px;
   border-radius: 50%;
+  background-color: #818181b9;  
   overflow: hidden;
-  border: 3px solid var(--primary-color);
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .image-preview img {

--- a/frontend/src/components/mypage/ProfileCreateModal.jsx
+++ b/frontend/src/components/mypage/ProfileCreateModal.jsx
@@ -3,21 +3,18 @@
 import { useState } from "react"
 import { getUserId, getRole } from "../../utils/storage"
 import { profileAPI } from "../../api"
+import SingleRegionSelector from "../SingleRegionSelector"
 import "./ProfileCreateModal.css"
 
-const ProfileCreateModal = ({ onClose, onProfileCreated, tags = [], regions = [] }) => {
+const ProfileCreateModal = ({ onClose, onProfileCreated, tags = [], regions = [], isIP }) => {
   const userId = getUserId()
   const role = getRole()
-
   if (!userId || !role) return <p>회원 정보를 불러오는 중입니다...</p>
-
-  const isIP = role === "ROLE_IP"
 
   const [loading, setLoading] = useState(false)
   const [formData, setFormData] = useState({
     name: "",
     description: "",
-    region: "",
     tags: [],
     profileImage: null,
     thumbnailImage: null,
@@ -26,92 +23,75 @@ const ProfileCreateModal = ({ onClose, onProfileCreated, tags = [], regions = []
     thumbnailPreview: null,
     extraPreviews: [],
     status: "true",
+    // STORE용 주소
+    addressCode: "",
+    address: "",
   })
 
   const handleChange = (e) => {
     const { name, value } = e.target
-    setFormData((prev) => ({
-      ...prev,
-      [name]: value,
-    }))
+    setFormData(prev => ({ ...prev, [name]: value }))
   }
 
   const handleTagChange = (e) => {
-    const selected = Array.from(e.target.selectedOptions).map((opt) => opt.value)
-    setFormData((prev) => ({
-      ...prev,
-      tags: selected,
-    }))
+    const selected = Array.from(e.target.selectedOptions).map(opt => opt.value)
+    setFormData(prev => ({ ...prev, tags: selected }))
   }
 
   const handleProfileImageChange = (e) => {
     const file = e.target.files[0]
-    if (file) {
-      setFormData((prev) => ({
-        ...prev,
-        profileImage: file,
-        imagePreview: URL.createObjectURL(file),
-      }))
-    }
+    if (file) setFormData(prev => ({
+      ...prev,
+      profileImage: file,
+      imagePreview: URL.createObjectURL(file)
+    }))
   }
 
   const handleThumbnailImageChange = (e) => {
     const file = e.target.files[0]
-    if (file) {
-      setFormData((prev) => ({
-        ...prev,
-        thumbnailImage: file,
-        thumbnailPreview: URL.createObjectURL(file),
-      }))
-    }
+    if (file) setFormData(prev => ({
+      ...prev,
+      thumbnailImage: file,
+      thumbnailPreview: URL.createObjectURL(file)
+    }))
   }
 
   const handleExtraImagesChange = (e) => {
     const files = Array.from(e.target.files)
-    const previews = files.map((file) => URL.createObjectURL(file))
-    setFormData((prev) => ({
-      ...prev,
-      extraImages: files,
-      extraPreviews: previews,
-    }))
+    const previews = files.map(f => URL.createObjectURL(f))
+    setFormData(prev => ({ ...prev, extraImages: files, extraPreviews: previews }))
+  }
+
+  // STORE 주소 토글바 선택 핸들러
+  const handleRegionSelect = (selection) => {
+    setFormData(prev => ({ ...prev, addressCode: selection.code, address: selection.fullAddress }))
   }
 
   const handleSubmit = async (e) => {
     e.preventDefault()
-
     try {
       setLoading(true)
 
       const data = new FormData()
-
       const profileRequest = {
         name: formData.name,
         description: formData.description,
-        addressId: formData.region || null,
         tagIds: formData.tags,
         status: formData.status === "true",
         type: isIP ? "IP" : "STORE",
+        addressCode: isIP ? null : formData.addressCode,
+        address: isIP ? null : formData.address,
       }
 
       data.append(
         "profileRequest",
         new Blob([JSON.stringify(profileRequest)], { type: "application/json" })
       )
-
-      if (formData.profileImage) {
-        data.append("profileImage", formData.profileImage)
-      }
-
-      if (formData.thumbnailImage) {
-        data.append("thumbnailImage", formData.thumbnailImage)
-      }
-
-      formData.extraImages.forEach((file) => {
-        data.append("extraImages", file)
-      })
+      if (formData.profileImage) data.append("profileImage", formData.profileImage)
+      if (formData.thumbnailImage) data.append("thumbnailImage", formData.thumbnailImage)
+      formData.extraImages.forEach(file => data.append("extraImages", file))
 
       const response = await profileAPI.createProfile(data)
-
       alert("프로필이 성공적으로 생성되었습니다.")
       onProfileCreated(response.data)
       onClose()
@@ -123,125 +103,97 @@ const ProfileCreateModal = ({ onClose, onProfileCreated, tags = [], regions = []
     }
   }
 
-  const safeRegions = Array.isArray(regions) ? regions : []
   const safeTags = Array.isArray(tags) ? tags : []
+  const safeRegions = Array.isArray(regions) ? regions : []
 
   return (
     <div className="modal-overlay" onClick={onClose}>
-      <div className="profile-create-modal" onClick={(e) => e.stopPropagation()}>
+      <div className="profile-create-modal" onClick={e => e.stopPropagation()}>
         <div className="modal-header">
           <h2>{isIP ? "새 IP 캐릭터 등록" : "새 매장 등록"}</h2>
-          <button className="modal-close" onClick={onClose}>
-            &times;
-          </button>
+          <button className="modal-close" onClick={onClose}>&times;</button>
         </div>
 
         <form onSubmit={handleSubmit} className="profile-create-form">
-          {/* 프로필 이미지 */}
+          {/* PROFILE 이미지 */}
           <div className="form-group">
             <label>프로필 이미지</label>
             <div className="image-upload">
               <div className="image-preview">
-                <img src={formData.imagePreview || "/placeholder-profile.png"} alt="프로필 이미지" />
+                <img src={formData.imagePreview || "/placeholder-profile.png"} alt="PROFILE" />
               </div>
               <input type="file" accept="image/*" onChange={handleProfileImageChange} required />
             </div>
           </div>
 
-          {/* 썸네일 이미지 */}
+          {/* THUMBNAIL 이미지 */}
           <div className="form-group">
             <label>썸네일 이미지</label>
             <div className="image-upload">
               <div className="image-preview">
-                <img src={formData.thumbnailPreview || "/placeholder-thumbnail.png"} alt="썸네일 이미지" />
+                <img src={formData.thumbnailPreview || "/placeholder-thumbnail.png"} alt="THUMBNAIL" />
               </div>
               <input type="file" accept="image/*" onChange={handleThumbnailImageChange} required />
             </div>
           </div>
 
-          {/* 추가 이미지 */}
+          {/* EXTRA 이미지 */}
           <div className="form-group">
             <label>추가 이미지 (선택)</label>
-            <div className="image-upload">
-              {formData.extraPreviews.map((src, idx) => (
-                <img key={idx} src={src} alt={`extra-${idx}`} style={{ width: "60px", marginRight: "5px" }} />
-              ))}
+            <div className="image-upload multiple">
+              <div className="image-previews">
+                {formData.extraPreviews.map((src, idx) => (
+                  <img key={idx} src={src} alt={`extra-${idx}`} width={60} />
+                ))}
+              </div>
               <input type="file" accept="image/*" multiple onChange={handleExtraImagesChange} />
             </div>
           </div>
 
-          {/* 이름 */}
+          {/* 이름 & 소개 */}
           <div className="form-group">
-            <label htmlFor="name">이름</label>
-            <input
-              type="text"
-              id="name"
-              name="name"
-              value={formData.name}
-              onChange={handleChange}
-              className="form-control"
-              required
-            />
+            <label>이름</label>
+            <input name="name" value={formData.name} onChange={handleChange} className="form-control" required />
+          </div>
+          <div className="form-group">
+            <label>소개</label>
+            <textarea name="description" value={formData.description} onChange={handleChange} className="form-control" rows={4} required />
           </div>
 
-          {/* 소개 */}
-          <div className="form-group">
-            <label htmlFor="description">소개</label>
-            <textarea
-              id="description"
-              name="description"
-              value={formData.description}
-              onChange={handleChange}
-              className="form-control"
-              rows="4"
-              required
-            />
-          </div>
+          {/* 주소 선택: STORE만 */}
+          {!isIP && (
+            <div className="form-group">
+              <label>주소 선택</label>
+              <SingleRegionSelector
+                regions={safeRegions}
+                selectedCode={formData.addressCode}
+                onSelect={handleRegionSelect}
+              />
+              {formData.address && <p className="selected-address">선택된 주소: {formData.address}</p>}
+            </div>
+          )}
 
-          {/* 지역 */}
+          {/* 태그 선택 */}
           <div className="form-group">
-            <label htmlFor="region">지역</label>
-            <select
-              id="region"
-              name="region"
-              value={formData.region}
-              onChange={handleChange}
-              className="form-control"
-            >
-              <option value="">지역 선택</option>
-              {safeRegions.map((region) => (
-                <option key={region.id} value={region.id}>
-                  {region.name}
-                </option>
+            <label>태그 (여러 개 선택 가능)</label>
+            <select multiple value={formData.tags} onChange={handleTagChange} className="form-control" required>
+              {safeTags.map(tag => (
+                <option key={tag.id} value={tag.id}>{tag.name}</option>
               ))}
+            </select>
+            <small>Ctrl 또는 Command 키를 누르고 선택하세요.</small>
+          </div>
+
+          {/* 상태 */}
+          <div className="form-group">
+            <label>상태</label>
+            <select name="status" value={formData.status} onChange={handleChange} className="form-control">
+              <option value="true">활성</option>
+              <option value="false">비활성</option>
             </select>
           </div>
 
-          {/* 태그 */}
-          <div className="form-group">
-            <label htmlFor="tags">태그 (여러 개 선택 가능)</label>
-            <select
-              id="tags"
-              name="tags"
-              multiple
-              value={formData.tags}
-              onChange={handleTagChange}
-              className="form-control"
-            >
-              {safeTags.map((tag) => (
-                <option key={tag.id} value={tag.id}>
-                  {tag.name}
-                </option>
-              ))}
-            </select>
-            <small>Ctrl 키 또는 Command 키를 누른 상태로 여러 개 선택할 수 있습니다.</small>
-          </div>
-
-          <div className="form-info">
-            <p>프로필 유형: {isIP ? "IP 제공자" : "점주"}</p>
-          </div>
-
-          {/* 버튼 */}
+          {/* Action Buttons */}
           <div className="form-actions">
             <button type="submit" className="btn btn-primary" disabled={loading}>
               {loading ? "생성 중..." : "프로필 생성"}

--- a/frontend/src/components/mypage/ProfileEdit.css
+++ b/frontend/src/components/mypage/ProfileEdit.css
@@ -66,7 +66,7 @@
 }
 
 .profile-location {
-  color: #666;
+  color: #dadada8f;
   font-size: 14px;
   display: flex;
   align-items: center;

--- a/frontend/src/components/mypage/ProfileEdit.css
+++ b/frontend/src/components/mypage/ProfileEdit.css
@@ -82,6 +82,7 @@
   color: #333;
   display: -webkit-box;
   -webkit-line-clamp: 3;
+  line-clamp: 3;
   -webkit-box-orient: vertical;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/frontend/src/components/mypage/ProfileEdit.jsx
+++ b/frontend/src/components/mypage/ProfileEdit.jsx
@@ -118,11 +118,20 @@ useEffect(() => {
       tags: profile.tags.map(t => t.id),
       status: profile.status.toString(),
       profileImageFile: null,
-      profileImagePreview: profile.profileImageUrl,
+      profileImagePreview: profile.profileImageUrl // 파일명만 들고있던 기존 상태 -> 파일명이 있으면 로컬8080 전체url 주고 없으면 널
+        ? `http://localhost:8080/api/files/images/${profile.profileImageUrl}`
+        : "",
+
       thumbnailImageFile: null,
-      thumbnailImagePreview: profile.thumbnailImageUrl,
+      thumbnailImagePreview: profile.thumbnailImageUrl
+        ? `http://localhost:8080/api/files/images/${profile.thumbnailImageUrl}`
+        : "",
+
       extraImageFiles: [],
-      extraImagePreviews: profile.extraImageUrls || [],
+      extraImagePreviews: Array.isArray(profile.extraImageUrls)
+        ? `http://localhost:8080/api/files/images/${name}`
+        : [],
+
       addressCode: profile.addressCode || "",
       address: profile.address || "",
     })
@@ -266,7 +275,12 @@ useEffect(() => {
             <label>프로필 이미지 (PROFILE)</label>
             <div className="image-upload">
               <div className="image-preview">
-                <img src={formData.profileImagePreview || "/placeholder-profile.png"} alt="PROFILE" />
+                <img
+                  src={formData.profileImagePreview }
+                  alt=""
+                  onError={e => { e.currentTarget.src = "" }} 
+                  style={{ backgroundColor: "#f0f0f0" }}
+                />
               </div>
               <input type="file" accept="image/*" onChange={handleProfileImageChange} />
             </div>
@@ -277,7 +291,15 @@ useEffect(() => {
             <label>썸네일 이미지 (THUMBNAIL)</label>
             <div className="image-upload">
               <div className="image-preview">
-                <img src={formData.thumbnailImagePreview || "/placeholder-profile.png"} alt="THUMBNAIL" />
+                <img
+                  src={formData.thumbnailImagePreview }
+                  alt=""
+                  onError={e => {
+                    e.currentTarget.onerror = null;
+                    e.currentTarget.src = ""
+                  }}
+                  style={{ backgroundColor: "#f0f0f0" }}
+              />
               </div>
               <input type="file" accept="image/*" onChange={handleThumbnailChange} />
             </div>
@@ -424,12 +446,15 @@ useEffect(() => {
               {profiles.map(profile => (
                 <div key={profile.id} className="profile-card">
                   <div className="profile-image">
-                    <img
-                      src={profile.profileImageUrl
-                        ? `http://localhost:8080/api/files/images/${profile.profileImageUrl}`
-                        : "/placeholder-profile.png"}
-                      alt={profile.name}
-                    />
+                  <img
+                    src={`http://localhost:8080/api/files/images/${profile.imageUrl}`}
+                    alt=""
+                    onError={e => {
+                      e.currentTarget.onerror = null;    // 무한루프 방지
+                      e.currentTarget.src = "";
+                    }}
+                    style={{ backgroundColor: "#f0f0f0" }}
+                  />
                     <div className={`status-badge ${profile.status ? "active" : "inactive"}`}>
                       {profile.status ? "활성" : "비활성"}
                     </div>

--- a/frontend/src/components/mypage/ProfileEdit.jsx
+++ b/frontend/src/components/mypage/ProfileEdit.jsx
@@ -2,153 +2,204 @@
 
 import { useState, useEffect } from "react"
 import { getUserId, getRole } from "../../utils/storage"
-import { profileAPI, tagAPI, regionAPI, userAPI } from "../../api"
+import { profileAPI, tagAPI, regionAPI } from "../../api"
 import ProfileCreateModal from "./ProfileCreateModal"
+import SingleRegionSelector from "../SingleRegionSelector"
 import "./ProfileEdit.css"
+
+
 
 const ProfileEdit = () => {
   const userId = parseInt(getUserId(), 10)
   const role = getRole()
+  const [provinces, setProvinces]       = useState([])     // 시/도
+  const [districts, setDistricts]       = useState([])     // 시/군/구
+  const [neighborhoods, setNeighborhoods] = useState([])    // 읍/면/동
 
+  const [selProvince, setSelProvince]       = useState(null)
+  const [selDistrict, setSelDistrict]       = useState(null)
+  const [selNeighborhood, setSelNeighborhood] = useState(null)
   if (!userId || !role) return null
 
-  const isIP = role === "ROLE_IP"
+  const isIP    = role === "ROLE_IP"
+  const isStore = role === "ROLE_STORE"
 
   const [profiles, setProfiles] = useState([])
-  const [tags, setTags] = useState([])
-  //const [regions, setRegions] = useState([])
+  const [allTags, setAllTags] = useState([])
+  const [regions, setRegions] = useState([])
   const [editingProfile, setEditingProfile] = useState(null)
   const [showCreateModal, setShowCreateModal] = useState(false)
-  const [formData, setFormData] = useState({
-    name: "",
-    description: "",
-    region: "",
-    tags: [],
-    imageFile: null,
-    imagePreview: null,
-    status: "true",
-  })
   const [loading, setLoading] = useState(true)
 
-  
+  const initialForm = {
+    name: "",
+    description: "",
+    tags: [],
+    status: "true",
+    // images
+    profileImageFile: null,
+    profileImagePreview: null,
+    thumbnailImageFile: null,
+    thumbnailImagePreview: null,
+    extraImageFiles: [],
+    extraImagePreviews: [],
+    // address for STORE
+    addressCode: "",
+    address: "",
+  }
+  const [formData, setFormData] = useState(initialForm)
 
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const [profilesResponse, tagsResponse, regionsResponse] = await Promise.all([
+        const [profilesRes, tagsRes, provincesRes] = await Promise.all([
           profileAPI.getUserProfiles(userId),
           tagAPI.getAllTags(),
-          //regionAPI.getAllRegions(),
+         
         ])
-        console.log("userId sent to getUserProfiles:", userId)
+        setProfiles(profilesRes.data || [])
+        setAllTags(tagsRes.data)
+        
+         // **시/도 목록만 미리 가져오기**
+         const provRes = await regionAPI.getAddress()
+         setProvinces(provRes.data.result || [])
 
-        setProfiles(profilesResponse.data || [])
-        setTags(tagsResponse.data)
-       // setRegions(regionsResponse.data)
-      } catch (error) {
-        console.error("Error fetching data:", error)
+      } catch (err) {
+        console.error("Error fetching data:", err)
       } finally {
         setLoading(false)
       }
     }
-
     fetchData()
   }, [userId])
 
-  const resetForm = () => {
-    setFormData({
-      name: "",
-      description: "",
-      region: "",
-      tags: [],
-      imageFile: null,
-      imagePreview: null,
-      status: "true",
-    })
+  const filteredTags = allTags.filter(tag => {
+    const t = tag.tagType ?? tag.type
+    if (isIP)    return t === "IP"
+    if (isStore) return t === "STORE"
+    return false
+  })
+  // selProvince 변경 시
+useEffect(() => {
+  if (!selProvince) {
+    setDistricts([])
+    return
   }
+  regionAPI.getAddress(selProvince.cd)
+    .then(res => {
+      setDistricts(res.data.result || [])
+      setSelDistrict(null)
+      setNeighborhoods([])
+    })
+    .catch(console.error)
+}, [selProvince])
+
+// selDistrict 변경 시
+useEffect(() => {
+  if (!selDistrict) {
+    setNeighborhoods([])
+    return
+  }
+  regionAPI.getAddress(selDistrict.cd)
+    .then(res => {
+      setNeighborhoods(res.data.result || [])
+      setSelNeighborhood(null)
+    })
+    .catch(console.error)
+}, [selDistrict])
+
+  const resetForm = () => setFormData(initialForm)
 
   const handleEditClick = (profile) => {
     setEditingProfile(profile)
-
     setFormData({
       name: profile.name,
       description: profile.description,
-      //region: profile.region.id,
-      tags: profile.tags.map((tag) => tag.id),
-      imageFile: null,
-      imagePreview: profile.imageUrl,
+      tags: profile.tags.map(t => t.id),
       status: profile.status.toString(),
+      profileImageFile: null,
+      profileImagePreview: profile.profileImageUrl,
+      thumbnailImageFile: null,
+      thumbnailImagePreview: profile.thumbnailImageUrl,
+      extraImageFiles: [],
+      extraImagePreviews: profile.extraImageUrls || [],
+      addressCode: profile.addressCode || "",
+      address: profile.address || "",
     })
   }
 
-  const handleCreateClick = () => {
-    setShowCreateModal(true)
-  }
+  const handleCreateClick = () => setShowCreateModal(true)
 
   const handleChange = (e) => {
     const { name, value } = e.target
-    setFormData((prev) => ({
-      ...prev,
-      [name]: value,
-    }))
+    setFormData(prev => ({ ...prev, [name]: value }))
   }
 
   const handleTagChange = (e) => {
-    const options = e.target.options
-    const selectedTags = []
+    const selected = Array.from(e.target.selectedOptions).map(o => o.value)
+    setFormData(prev => ({ ...prev, tags: selected }))
+  }
 
-    for (let i = 0; i < options.length; i++) {
-      if (options[i].selected) {
-        selectedTags.push(options[i].value)
-      }
-    }
-
-    setFormData((prev) => ({
+  const handleProfileImageChange = (e) => {
+    const file = e.target.files[0]
+    if (file) setFormData(prev => ({
       ...prev,
-      tags: selectedTags,
+      profileImageFile: file,
+      profileImagePreview: URL.createObjectURL(file)
+    }))
+  }
+  const handleThumbnailChange = (e) => {
+    const file = e.target.files[0]
+    if (file) setFormData(prev => ({
+      ...prev,
+      thumbnailImageFile: file,
+      thumbnailImagePreview: URL.createObjectURL(file)
+    }))
+  }
+  const handleExtraImagesChange = (e) => {
+    const files = Array.from(e.target.files)
+    const previews = files.map(f => URL.createObjectURL(f))
+    setFormData(prev => ({
+      ...prev,
+      extraImageFiles: files,
+      extraImagePreviews: previews
     }))
   }
 
-  const handleImageChange = (e) => {
-    const file = e.target.files[0]
-    if (file) {
-      setFormData((prev) => ({
-        ...prev,
-        imageFile: file,
-        imagePreview: URL.createObjectURL(file),
-      }))
-    }
+  const handleRegionSelect = (selection) => {
+    setFormData(prev => ({
+      ...prev,
+      addressCode: selection.code,
+      address: selection.fullAddress
+    }))
   }
 
   const handleSubmit = async (e) => {
     e.preventDefault()
-
     try {
       setLoading(true)
-
-      const formDataToSend = new FormData()
-      formDataToSend.append("name", formData.name)
-      formDataToSend.append("description", formData.description)
-      //formDataToSend.append("regionId", formData.region)
-      formData.tags.forEach((tagId) => {
-        formDataToSend.append("tagIds", tagId)
-      })
-      formDataToSend.append("status", formData.status)
-
-      if (formData.imageFile) {
-        formDataToSend.append("image", formData.imageFile)
+      const data = new FormData()
+      data.append("name", formData.name)
+      data.append("description", formData.description)
+      data.append("status", formData.status)
+      formData.tags.forEach(id => data.append("tagIds", id))
+      // address if STORE
+      if (!isIP) {
+        data.append("addressCode", formData.addressCode)
+        data.append("address", formData.address)
       }
+      // images
+      if (formData.profileImageFile) data.append("profileImage", formData.profileImageFile)
+      if (formData.thumbnailImageFile) data.append("thumbnailImage", formData.thumbnailImageFile)
+      formData.extraImageFiles.forEach(file => data.append("extraImages", file))
 
-      await profileAPI.updateProfile(editingProfile.id, formDataToSend)
-
-      // Refresh profiles
-      const profilesResponse = await profileAPI.getUserProfiles(userId)
-      setProfiles(profilesResponse.data.profiles || [])
-
+      await profileAPI.updateProfile(editingProfile.id, data)
+      const refreshed = await profileAPI.getUserProfiles(userId)
+      setProfiles(refreshed.data || [])
       setEditingProfile(null)
       resetForm()
-    } catch (error) {
-      console.error("Error saving profile:", error)
+    } catch (err) {
+      console.error("Error saving profile:", err)
       alert("프로필 저장에 실패했습니다.")
     } finally {
       setLoading(false)
@@ -160,37 +211,21 @@ const ProfileEdit = () => {
     resetForm()
   }
 
-  const handleProfileCreated = async (newProfile) => {
-    // Refresh profiles after creation // 
-    //const profilesResponse = await userAPI.getProfile(userId)
-    const profilesResponse = await profileAPI.getUserProfiles(userId)
-    setProfiles(profilesResponse.data || [])
-  }
-
-  // 프로필 삭제 핸들러 추가
-  const handleDeleteProfile = async (profileId) => {
-    if (!window.confirm("정말로 이 프로필을 삭제하시겠습니까?")) {
-      return
-    }
-
+  const handleDeleteProfile = async (id) => {
+    if (!window.confirm("정말로 프로필을 삭제하시겠습니까?")) return
     try {
       setLoading(true)
-      await profileAPI.deleteProfile(profileId)
-
-      // 프로필 목록 새로고침
-      const profilesResponse = await profileAPI.getUserProfiles(userId)
-      setProfiles(profilesResponse.data.profiles || [])
-
+      await profileAPI.deleteProfile(id)
+      const refreshed = await profileAPI.getUserProfiles(userId)
+      setProfiles(refreshed.data || [])
       alert("프로필이 삭제되었습니다.")
-    } catch (error) {
-      console.error("Error deleting profile:", error)
+    } catch (err) {
+      console.error(err)
       alert("프로필 삭제에 실패했습니다.")
     } finally {
       setLoading(false)
     }
   }
-
-  
 
   return (
     <div className="profile-edit">
@@ -205,79 +240,153 @@ const ProfileEdit = () => {
         <form onSubmit={handleSubmit} className="profile-form">
           <h3>프로필 수정</h3>
 
+          {/* PROFILE Image */}
           <div className="form-group">
-            <label>프로필 이미지</label>
+            <label>프로필 이미지 (PROFILE)</label>
             <div className="image-upload">
               <div className="image-preview">
-                <img src={formData.imagePreview || "/placeholder-profile.png"} alt="프로필 이미지" />
+                <img src={formData.profileImagePreview || "/placeholder-profile.png"} alt="PROFILE" />
               </div>
-              <input type="file" accept="image/*" onChange={handleImageChange} />
+              <input type="file" accept="image/*" onChange={handleProfileImageChange} />
             </div>
           </div>
 
+          {/* THUMBNAIL Image */}
+          <div className="form-group">
+            <label>썸네일 이미지 (THUMBNAIL)</label>
+            <div className="image-upload">
+              <div className="image-preview">
+                <img src={formData.thumbnailImagePreview || "/placeholder-profile.png"} alt="THUMBNAIL" />
+              </div>
+              <input type="file" accept="image/*" onChange={handleThumbnailChange} />
+            </div>
+          </div>
+
+          {/* EXTRA Images */}
+          <div className="form-group">
+            <label>추가 이미지 (EXTRA)</label>
+            <div className="image-upload multiple">
+              <div className="image-previews">
+                {formData.extraImagePreviews.map((src, idx) => (
+                  <img key={idx} src={src} alt={`extra-${idx}`} />
+                ))}
+              </div>
+              <input type="file" accept="image/*" multiple onChange={handleExtraImagesChange} />
+            </div>
+          </div>
+
+          {/* Name, Description */}
           <div className="form-group">
             <label htmlFor="name">이름</label>
-            <input
-              type="text"
-              id="name"
-              name="name"
-              value={formData.name}
-              onChange={handleChange}
-              className="form-control"
-              required
-            />
+            <input id="name" name="name" value={formData.name} onChange={handleChange} className="form-control" required />
           </div>
-
           <div className="form-group">
             <label htmlFor="description">소개</label>
-            <textarea
-              id="description"
-              name="description"
-              value={formData.description}
-              onChange={handleChange}
-              className="form-control"
-              rows="4"
-              required
-            ></textarea>
+            <textarea id="description" name="description" value={formData.description} onChange={handleChange} className="form-control" rows={4} required />
           </div>
 
-        
-
+          {/* Address (STORE only) */}
+          {!isIP && (
           <div className="form-group">
-            <label htmlFor="tags">태그 (여러 개 선택 가능)</label>
-            <select
-              id="tags"
-              name="tags"
-              multiple
-              value={formData.tags}
-              onChange={handleTagChange}
-              className="form-control"
-              required
-            >
-              {tags.map((tag) => (
-                <option key={tag.id} value={tag.id}>
-                  {tag.name}
-                </option>
+            <label>주소 선택</label>
+            <div className="region-dropdowns">
+              <select
+                value={selProvince?.cd || ""}
+                onChange={e => {
+                  const prov = provinces.find(p => p.cd === e.target.value);
+                  setSelProvince(prov || null);
+                  setFormData(prev => ({
+                    ...prev,
+                    addressCode: prov?.cd || "",
+                    address: prov ? prov.addr_name : ""
+                  }));
+                }}
+              >
+                <option value="">시/도 선택</option>
+                {provinces.map(p => (
+                  <option key={p.cd} value={p.cd}>
+                    {p.addr_name}
+                  </option>
+                ))}
+              </select>
+
+              <select
+                disabled={!selProvince}
+                value={selDistrict?.cd || ""}
+                onChange={e => {
+                  const dist = districts.find(d => d.cd === e.target.value);
+                  setSelDistrict(dist || null);
+                  setFormData(prev => ({
+                    ...prev,
+                    addressCode: dist?.cd || prev.addressCode,
+                    address: dist
+                      ? `${selProvince.addr_name} ${dist.addr_name}`
+                      : prev.address
+                  }));
+                }}
+              >
+                <option value="">시/군/구 선택</option>
+                {districts.map(d => (
+                  <option key={d.cd} value={d.cd}>
+                    {d.addr_name}
+                  </option>
+                ))}
+              </select>
+
+              <select
+                disabled={!selDistrict}
+                value={selNeighborhood?.cd || ""}
+                onChange={e => {
+                  const hood = neighborhoods.find(n => n.cd === e.target.value);
+                  setSelNeighborhood(hood || null);
+                  setFormData(prev => ({
+                    ...prev,
+                    addressCode: hood?.cd || prev.addressCode,
+                    address: hood
+                      ? `${selProvince.addr_name} ${selDistrict.addr_name} ${hood.addr_name}`
+                      : prev.address
+                  }));
+                }}
+              >
+                <option value="">읍/면/동 선택</option>
+                {neighborhoods.map(n => (
+                  <option key={n.cd} value={n.cd}>
+                    {n.addr_name}
+                  </option>
+                ))}
+              </select>
+            </div>
+            {formData.address && (
+              <p className="selected-address">선택된 주소: {formData.address}</p>
+            )}
+          </div>
+          )}
+
+
+          {/* Tags */}
+          <div className="form-group">
+            <label>태그 (여러 개 선택 가능)</label>
+            <select multiple value={formData.tags} onChange={handleTagChange} className="form-control" >
+              {filteredTags.map(tag => (
+                <option key={tag.id} value={tag.id}>{tag.name}</option>
               ))}
             </select>
-            <small>Ctrl 키를 누른 상태에서 여러 개 선택 가능합니다.</small>
+            <small>Ctrl 키를 누르고 선택하세요.</small>
           </div>
 
+          {/* Status */}
           <div className="form-group">
-            <label htmlFor="status">상태</label>
-            <select id="status" name="status" value={formData.status} onChange={handleChange} className="form-control">
+            <label>상태</label>
+            <select name="status" value={formData.status} onChange={handleChange} className="form-control">
               <option value="true">활성</option>
               <option value="false">비활성</option>
             </select>
           </div>
 
+          {/* Actions */}
           <div className="form-actions">
-            <button type="submit" className="btn btn-primary">
-              저장
-            </button>
-            <button type="button" className="btn btn-secondary" onClick={handleCancel}>
-              취소
-            </button>
+            <button type="submit" className="btn btn-primary">저장</button>
+            <button type="button" className="btn btn-secondary" onClick={handleCancel}>취소</button>
           </div>
         </form>
       ) : (
@@ -291,47 +400,32 @@ const ProfileEdit = () => {
             </div>
           ) : (
             <div className="profiles-grid">
-              {profiles.map((profile) => (
+              {profiles.map(profile => (
                 <div key={profile.id} className="profile-card">
                   <div className="profile-image">
-                    <img 
-                      src={`http://localhost:8080/api/files/images/${profile.imageUrl}` || "/placeholder-profile.png"}
-                      // src={profile.imageUrl || "/placeholder-profile.png"} 
-                      alt={profile.name} 
+                    <img
+                      src={profile.profileImageUrl
+                        ? `http://localhost:8080/api/files/images/${profile.profileImageUrl}`
+                        : "/placeholder-profile.png"}
+                      alt={profile.name}
                     />
                     <div className={`status-badge ${profile.status ? "active" : "inactive"}`}>
                       {profile.status ? "활성" : "비활성"}
                     </div>
                   </div>
-
                   <div className="profile-info">
                     <h3>{profile.name}</h3>
-                  
                     <p className="profile-description">{profile.description}</p>
-
                     <div className="profile-meta">
-                      <span className="created-date">생성일: {new Date(profile.createdAt).toLocaleDateString()}</span>
-                      <span className="collabo-count">콜라보 횟수: {profile.collaboCount || 0}</span>
+                      <span>생성일: {new Date(profile.createdAt).toLocaleDateString()}</span>
+                      <span>콜라보 횟수: {profile.collaboCount || 0}</span>
                     </div>
-
                     <div className="profile-tags">
-                      {profile.tags.map((tag) => (
-                        <span key={tag.id} className="tag">
-                          {tag.name}
-                        </span>
-                      ))}
+                      {profile.tags.map(tag => <span key={tag.id} className="tag">{tag.name}</span>)}
                     </div>
-
                     <div className="profile-actions">
-                      <button className="btn btn-primary edit-profile-btn" onClick={() => handleEditClick(profile)}>
-                        수정
-                      </button>
-                      <button
-                        className="btn btn-danger delete-profile-btn"
-                        onClick={() => handleDeleteProfile(profile.id)}
-                      >
-                        삭제
-                      </button>
+                      <button className="btn btn-primary" onClick={() => handleEditClick(profile)}>수정</button>
+                      <button className="btn btn-danger" onClick={() => handleDeleteProfile(profile.id)}>삭제</button>
                     </div>
                   </div>
                 </div>
@@ -344,9 +438,13 @@ const ProfileEdit = () => {
       {showCreateModal && (
         <ProfileCreateModal
           onClose={() => setShowCreateModal(false)}
-          onProfileCreated={handleProfileCreated}
-          tags={tags}
-     
+          onProfileCreated={async () => {
+            const res = await profileAPI.getUserProfiles(userId)
+            setProfiles(res.data || [])
+          }}
+          tags={filteredTags}
+          regions={regions}
+          isIP={isIP}
         />
       )}
     </div>

--- a/frontend/src/pages/RecruitmentListPage.jsx
+++ b/frontend/src/pages/RecruitmentListPage.jsx
@@ -150,7 +150,7 @@ const RecruitmentListPage = () => {
 
             return (
               <div key={recruitment.id} className="recruitment-card" onClick={(e) => handleRecruitmentClick(recruitment, e)}>
-                <div className={`recruitment-tag ${isIP ? "ip-tag" : "store-tag"}`}>{isIP ? "IP캐릭터모집" : "매장모집"}</div>
+                <div className={`recruitment-tag ${isIP ? "ip-tag" : "store-tag"}`}>{isIP ? "매장모집" : "IP캐릭터모집" }</div>
                 <div className="recruitment-status">{statusLabel}</div>
                 <h2 className="recruitment-title">{recruitment.title}</h2>
                 <div className="recruitment-info">


### PR DESCRIPTION
## 📌 관련 이슈
#87 

## 💡 구현 내용 요약

## FE: 프로필 관련 변경사항
- [x] 프로필 생성/수정 시 주소 시군구동 토글바 입력 
  -  주소 토글바는 매장 타입 프로필에게만 보임
  - SGIS API 이용
  - 법정동코드와 전체 주소 문자열이 Profile의 adressCode, address에 저장됨
  <br>
- [x] 프로필 수정 시 3가지 타입의 이미지 수정 가능하도록 변경
- [x] A 타입 프로필이 작성한 모집공고 A모집이 아닌 B모집으로 표시되도록 변경
- [x] 마이페이지 프로필 목록에서 PROFILE 타입 이미지 미리보기 

## BE: 프로필 관련 변경사항
- [x] 프로필 수정 시 status 변경  update할 수 있도록 profile의 RequestDto, ResponseDto 수정

## ✅ 작업 상세 내용


## 📸 스크린샷(선택)
- UI 작업이면 전/후 비교 캡쳐

## 🧪 테스트 여부
- [x] 프로필 생성/수정시 모든 변경사항 DB 적용 확인 (이미지3종, 상태, 주소, 소개 등)
- [x] 프로필이 주소로 메인페이지에서 조회되는지 확인
- [x] 활성화된 프로필만 메인페이지에서 조회되는지 확인

## 📎 기타 참고 사항
- 코드 리뷰 시 유의할 점이나 질문 등




## 📎 관련 자료
